### PR TITLE
Modified styling of the copy buttons to be part of the textarea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 # Logs
 logs
 *.log

--- a/public/assets/index.css
+++ b/public/assets/index.css
@@ -49,6 +49,8 @@ body {
     overflow: hidden;
     height: 3.5rem;
     line-height: 1.5;
+    border-top: none;
+    border-bottom: none;
 }
 
 .input-group {

--- a/public/pages/template.html
+++ b/public/pages/template.html
@@ -15,24 +15,25 @@
 <div class="input-group">
     <textarea class="form-control copy-field" id="md" readonly>
 [![GitLicense](https://gitlicense.com/badge/{{account}}/{{repo}})](https://gitlicense.com/license/{{account}}/{{repo}})</textarea>
-    <button class="btn btn-default" data-clipboard-target="#md">
-        <i class="fa fa-copy"></i>
-    </button>
+    <span class="input-group-addon btn btn-default" data-clipboard-target="#md">
+          <i class="fa fa-copy"></i>
+    </span>
 </div>
 <h2>reStructuredText</h2>
 <div class="input-group">
     <textarea class="form-control copy-field" id="re" readonly>
 .. image:: https://gitlicense.com/badge/{{account}}/{{repo}}
   :target: https://gitlicense.com/license/{{account}}/{{repo}}</textarea>
-    <button class="btn btn-default" data-clipboard-target="#re">
-        <i class="fa fa-copy"></i>
-    </button>
+    <span class="input-group-addon btn btn-default" data-clipboard-target="#re">
+          <i class="fa fa-copy"></i>
+    </span>
 </div>
 <h2>HTML</h2>
 <div class="input-group">
     <textarea class="form-control copy-field" id="ht" readonly>
 &lt;a href='https://gitlicense.com/license/{{account}}/{{repo}}'&gt;&lt;img src='https://gitlicense.com/badge/{{account}}/{{repo}}'/&gt;&lt;/a&gt;</textarea>
-    <button class="btn btn-default" data-clipboard-target="#ht">
-        <i class="fa fa-copy"></i>
-    </button>
+    <span class="input-group-addon btn btn-default" data-clipboard-target="#ht">
+          <i class="fa fa-copy"></i>
+    </span>
+</div>
 </div>

--- a/public/pages/template.html
+++ b/public/pages/template.html
@@ -36,4 +36,3 @@
           <i class="fa fa-copy"></i>
     </span>
 </div>
-</div>


### PR DESCRIPTION
See #13 as main story. 

This currently just uses a different styling for the buttons to integrate them better with the textareas. 

Preview: 
<img width="661" alt="preview" src="https://user-images.githubusercontent.com/4199845/31068246-7ecfd3be-a757-11e7-9211-dbbe72010471.png">


Further I added `*.swp` files to .gitignore for vim users 😉 